### PR TITLE
Deleting the semicolon.

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -298,7 +298,7 @@ public class MyDirective extends Directive {
 }
 
 //mybatis-velocity.properties
-userdirective=com.myproject.directives.MyDirective,com.myproject.directives.SpecialDirective;
+userdirective=com.myproject.directives.MyDirective,com.myproject.directives.SpecialDirective
 
 // mapper xml file
 SELECT *


### PR DESCRIPTION
Deleting the semicolon from the document of the Mybatis-Velocity.property part.
Related issue: #53 