### PR TITLE
How about turning off the default build reports generation feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <gcu.product>Velocity</gcu.product>
     <module.name>org.mybatis.scripting.velocity</module.name>
     <clirr.comparisonVersion>2.0</clirr.comparisonVersion>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencies>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
